### PR TITLE
fix(imports): pass matplotlib ImportError

### DIFF
--- a/docs/examples/plot_cmeans.py
+++ b/docs/examples/plot_cmeans.py
@@ -22,7 +22,10 @@ test data to work with.
 """
 from __future__ import division, print_function
 import numpy as np
-import matplotlib.pyplot as plt
+try:
+    import matplotlib.pyplot as plt
+except ImportError:
+    pass
 import skfuzzy as fuzz
 
 colors = ['b', 'orange', 'g', 'r', 'c', 'm', 'y', 'k', 'Brown', 'ForestGreen']

--- a/docs/examples/plot_defuzzify.py
+++ b/docs/examples/plot_defuzzify.py
@@ -11,7 +11,10 @@ There are several possible methods for defuzzification, exposed via
 
 """
 import numpy as np
-import matplotlib.pyplot as plt
+try:
+    import matplotlib.pyplot as plt
+except ImportError:
+    pass
 import skfuzzy as fuzz
 
 

--- a/docs/examples/plot_tipping_problem.py
+++ b/docs/examples/plot_tipping_problem.py
@@ -35,7 +35,10 @@ are defined in scikit-fuzzy as follows
 """
 import numpy as np
 import skfuzzy as fuzz
-import matplotlib.pyplot as plt
+try:
+    import matplotlib.pyplot as plt
+except ImportError:
+    pass
 
 # Generate universe variables
 #   * Quality and service on subjective ranges [0, 10]

--- a/docs/ext/plot2rst.py
+++ b/docs/ext/plot2rst.py
@@ -74,9 +74,12 @@ import traceback
 import itertools
 
 import numpy as np
-import matplotlib
-matplotlib.use('Agg')
-import matplotlib.pyplot as plt
+try:
+    import matplotlib
+    matplotlib.use('Agg')
+    import matplotlib.pyplot as plt
+except ImportError:
+    pass
 
 from skimage import io
 from skimage import transform

--- a/docs/ext/plot_directive.py
+++ b/docs/ext/plot_directive.py
@@ -133,12 +133,14 @@ except ImportError:
     def format_template(template, **kw):
         return jinja.from_string(template, **kw)
 
-
-import matplotlib
-import matplotlib.cbook as cbook
-matplotlib.use('Agg')
-import matplotlib.pyplot as plt
-from matplotlib import _pylab_helpers
+try:
+    import matplotlib
+    import matplotlib.cbook as cbook
+    matplotlib.use('Agg')
+    import matplotlib.pyplot as plt
+    from matplotlib import _pylab_helpers
+except ImportError:
+    pass
 
 __version__ = 2
 

--- a/docs/logo/skfuzzy_icon.py
+++ b/docs/logo/skfuzzy_icon.py
@@ -3,7 +3,10 @@ import skfuzzy as fuzz
 import scipy.ndimage as ndi
 import skimage.io
 from skimage.transform import resize
-import matplotlib.pyplot as plt
+try:
+    import matplotlib.pyplot as plt
+except ImportError:
+    pass
 
 kwargs = {'lw': 20, 'solid_capstyle': 'round'}
 

--- a/docs/logo/skfuzzy_logo.py
+++ b/docs/logo/skfuzzy_logo.py
@@ -3,7 +3,10 @@ import skfuzzy as fuzz
 import scipy.ndimage as ndi
 import skimage.io
 from skimage.transform import rescale
-import matplotlib.pyplot as plt
+try:
+    import matplotlib.pyplot as plt
+except ImportError:
+    pass
 
 kwargs = {'lw': 20, 'solid_capstyle': 'round'}
 

--- a/docs/tools/plot_pr.py
+++ b/docs/tools/plot_pr.py
@@ -6,10 +6,12 @@ from datetime import datetime, timedelta
 from dateutil.relativedelta import relativedelta
 
 import numpy as np
-import matplotlib.pyplot as plt
-from matplotlib.ticker import FuncFormatter
-from matplotlib.transforms import blended_transform_factory
-
+try:
+    import matplotlib.pyplot as plt
+    from matplotlib.ticker import FuncFormatter
+    from matplotlib.transforms import blended_transform_factory
+except ImportError:
+    pass
 
 cache = '_pr_cache.txt'
 

--- a/skfuzzy/control/visualization.py
+++ b/skfuzzy/control/visualization.py
@@ -5,7 +5,10 @@ from __future__ import print_function, division
 
 import numpy as np
 import networkx as nx
-import matplotlib.pyplot as plt
+try:
+    import matplotlib.pyplot as plt
+except ImportError:
+    pass
 
 from ..fuzzymath.fuzzy_ops import interp_membership
 


### PR DESCRIPTION
Matplotlib is not a dependency, therefore its absence shouldn't cause problems
building or during execution.
Is possible to run into this problem specially on limited hardware.

The following changes have been made:
replace,
```python
import matplotlib.pyplot as plt
```
for,
```python
try:
    import matplotlib.pyplot as plt
except ImportError:
    pass
```
This changes allow the setup and use without matplotlib.